### PR TITLE
API Data Into Database

### DIFF
--- a/backend/api/FetchPlayers.js
+++ b/backend/api/FetchPlayers.js
@@ -1,15 +1,28 @@
 import dotenv from "dotenv";
 dotenv.config();
+import fs from 'fs'
+const fs = require('node:fs')
 
-export async function fetchPlayers() {
-  const res = await fetch("https://api-nba-v1.p.rapidapi.com/players", {
-    headers: {
-      "rapidapi-key": process.env.RAPIDAPI_KEY,
+const url = 'https://api-nba-v1.p.rapidapi.com/players?team=1&season=2021';
+const options = {
+	method: 'GET',
+	headers: {
+		"rapidapi-key": process.env.RAPIDAPI_KEY,
       "rapidapi-host": process.env.RAPIDAPI_HOST,
-    },
-  });
-  if (!res.ok) {
-    throw new Error(`There was an error getting players: ${res.statusText}`);
-  }
-  return res.json();
+	}
+};
+
+try {
+	const response = await fetch(url, options);
+	const result = await response.text();
+	fs.writeFile('file.txt', result, err => {
+		if (err) {
+			console.error(err)
+		} else  {
+			console.log("Fetch Players was a success")
+		}
+	})
+} catch (error) {
+	console.error(error);
 }
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -16,7 +16,7 @@ const leagueRouter = require("./routes/league");
 server.use("/api/league", leagueRouter);
 const fantasyTeamRouter = require("./routes/fantasyteam");
 server.use("/api", fantasyTeamRouter);
-const playerRouter = require("./routes/players");
+const playerRouter = require("./routes/player");
 server.use("/api", playerRouter);
 
 const PORT = process.env.PORT || 5000;

--- a/backend/index.js
+++ b/backend/index.js
@@ -16,6 +16,8 @@ const leagueRouter = require("./routes/league");
 server.use("/api/league", leagueRouter);
 const fantasyTeamRouter = require("./routes/fantasyteam");
 server.use("/api", fantasyTeamRouter);
+const playerRouter = require("./routes/players");
+server.use("/api", playerRouter);
 
 const PORT = process.env.PORT || 5000;
 server.listen(PORT, () => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^6.10.1",
+        "@prisma/client": "^6.11.1",
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -22,13 +22,13 @@
         "passport-facebook": "^3.0.0"
       },
       "devDependencies": {
-        "prisma": "^6.10.1"
+        "prisma": "^6.11.1"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.1.tgz",
-      "integrity": "sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.11.1.tgz",
+      "integrity": "sha512-5CLFh8QP6KxRm83pJ84jaVCeSVPQr8k0L2SEtOJHwdkS57/VQDcI/wQpGmdyOZi+D9gdNabdo8tj1Uk+w+upsQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
-      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.11.1.tgz",
+      "integrity": "sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -58,53 +58,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
-      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.11.1.tgz",
+      "integrity": "sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
-      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.11.1.tgz",
+      "integrity": "sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1",
-        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-        "@prisma/fetch-engine": "6.10.1",
-        "@prisma/get-platform": "6.10.1"
+        "@prisma/debug": "6.11.1",
+        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+        "@prisma/fetch-engine": "6.11.1",
+        "@prisma/get-platform": "6.11.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
-      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
+      "version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9.tgz",
+      "integrity": "sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
-      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.11.1.tgz",
+      "integrity": "sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1",
-        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-        "@prisma/get-platform": "6.10.1"
+        "@prisma/debug": "6.11.1",
+        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
+        "@prisma/get-platform": "6.11.1"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
-      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.11.1.tgz",
+      "integrity": "sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1"
+        "@prisma/debug": "6.11.1"
       }
     },
     "node_modules/accepts": {
@@ -1037,15 +1037,15 @@
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/prisma": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
-      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.11.1.tgz",
+      "integrity": "sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.10.1",
-        "@prisma/engines": "6.10.1"
+        "@prisma/config": "6.11.1",
+        "@prisma/engines": "6.11.1"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@prisma/client": "^6.10.1",
+    "@prisma/client": "^6.11.1",
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
@@ -24,6 +24,6 @@
     "passport-facebook": "^3.0.0"
   },
   "devDependencies": {
-    "prisma": "^6.10.1"
+    "prisma": "^6.11.1"
   }
 }

--- a/backend/prisma/migrations/20250711213221_added_ref_player/migration.sql
+++ b/backend/prisma/migrations/20250711213221_added_ref_player/migration.sql
@@ -1,0 +1,19 @@
+-- DropForeignKey
+ALTER TABLE "Player" DROP CONSTRAINT "Player_teamId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PlayerStatisticsPerGame" DROP CONSTRAINT "PlayerStatisticsPerGame_playerId_fkey";
+
+-- AlterTable
+ALTER TABLE "Player" ALTER COLUMN "teamId" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "RefPlayer" (
+    "id" INTEGER NOT NULL,
+    "metadata" JSONB NOT NULL,
+
+    CONSTRAINT "RefPlayer_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Player" ADD CONSTRAINT "Player_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,18 +19,17 @@ model User {
   email           String?  @unique
   facebookId      String   @unique
   provider        String
-  favoriteTeams   Team[]
-  favoritePlayers Player[]
-  leagues         League[]
+  favoriteTeams   String[] // Changed to String[] because id of model Team is a String type
+  favoritePlayers Int[] // Changed to Int[] becuase id of model Player is an Int type
+  leagues         Int[] // Changed to Int[] because id of model League is an Int type
 }
 
 model Team {
   id       String   @id // This is from the id the api assigns
-  players  Player[]
+  players  Int[] // This refers to refPlayer model
   city     String
   nickName String
   confName String
-  User     User[] // Only needed for compilation
 }
 
 model PlayerStatisticsPerGame {
@@ -58,13 +57,12 @@ model PlayerStatisticsPerGame {
   blocks        Int
   plusMinus     Int
   playerId      Int
-  player        Player @relation(fields: [playerId], references: [playerId])
 }
 
 model League {
   leagueId Int    @id
   name     String
-  users    User[]
+  users    Int[] // Changed to Int[] because model User has an id of type Int
 }
 
 model Transactions {
@@ -80,14 +78,17 @@ model Transactions {
 }
 
 model Player {
-  playerId  Int                       @id
+  playerId  Int     @id
   firstName String
   lastName  String
-  teamId    String
-  team      Team                      @relation(fields: [teamId], references: [id])
-  User      User[]
+  teamId    String? // Refers to real life team
+  fantasyTeamId     String? // Refers to fantasy team
   value     Int
-  stats     PlayerStatisticsPerGame[]
+}
+
+model RefPlayer {
+  id       Int  @id
+  metadata Json
 }
 
 model FantasyTeam {

--- a/backend/routes/fantasyteam.js
+++ b/backend/routes/fantasyteam.js
@@ -13,12 +13,10 @@ router.post("/:leagueId/fantasyteam", async (req, res) => {
     });
 
     if (existingTeam) {
-      return res
-        .status(400)
-        .json({
-          success: false,
-          error: "User already in fantasy team in this league",
-        });
+      return res.status(400).json({
+        success: false,
+        error: "User already in fantasy team in this league",
+      });
     }
 
     const fantasyTeam = await prisma.fantasyTeam.create({
@@ -32,29 +30,23 @@ router.post("/:leagueId/fantasyteam", async (req, res) => {
 
     return res.json({ success: true, fantasyTeam });
   } catch (error) {
-    return res.status(500).json({ success: false, error: "Not able to create fantasy team" });
+    return res
+      .status(500)
+      .json({ success: false, error: "Not able to create fantasy team" });
   }
 });
 
 // GET the roster
 router.get("/roster/:userId/:leagueId", async (req, res) => {
-  const {userId, leagueId} = req.params;
+  const { userId, leagueId } = req.params;
   try {
-    const fantasyTeam = await prisma.fantasyTeam.findUnique({
-      where: {
-        userId_leagueId: {
-          userId: Number(userId),
-          leagueId: Number(leagueId)
-        }
-      }
-    })
-    if (!fantasyTeam) {
-      return res.status(404).json({players: []})
-    }
-    return res.json({players: fantasyTeam.playerIds || []})
+    const fantasyTeam = await prisma.fantasyTeam.findFirst({
+      where: { userId: userId, leagueId: leagueId },
+    });
+    return res.json(fantasyTeam);
   } catch (error) {
-    return res.status(500).json({error: "Could not fetch roster"})
+    return res.status(500).json({ error: "Could not fetch roster" });
   }
-})
+});
 
 module.exports = router;

--- a/backend/routes/player.js
+++ b/backend/routes/player.js
@@ -1,0 +1,40 @@
+const express = require("express");
+const router = express.Router();
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+router.post("/players", async (req, res) => {
+  try {
+    const { id, firstName, lastName } = req.body;
+
+    const existingPlayer = await prisma.player.findUnique({
+      where: { playerId: id },
+    });
+
+    if (existingPlayer) {
+      return res
+        .status(400)
+        .json({
+          success: false,
+          error: "Player already in database",
+        });
+    }
+    const fullName = `${firstName} ${lastName}`
+    const player = await prisma.player.create({
+      data: {
+        id,
+        firstName,
+        lastName,
+        name: fullName,
+        playerIds: [],
+        value: 0,
+      },
+    });
+
+    return res.json({ success: true, player });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: "Not able to create player" });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/player.js
+++ b/backend/routes/player.js
@@ -3,6 +3,16 @@ const router = express.Router();
 const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
+router.get("/refPlayers", async (req, res) => {
+  try {
+    const players = await prisma.refPlayer.findMany();
+    return res.json(players);
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: 'Failed to fetch players' });
+  }
+});
+
 router.post("/players", async (req, res) => {
   try {
     const { id, firstName, lastName } = req.body;

--- a/backend/routes/playerload.js
+++ b/backend/routes/playerload.js
@@ -1,0 +1,32 @@
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+async function fetchNBAPlayers() {
+  const url = "https://api-nba-v1.p.rapidapi.com/players?team=1&season=2021";
+  const options = {
+    method: "GET",
+    headers: {
+      "rapidapi-key": "cbca1b28d7msh153cb400f5cac43p1467e4jsn3649d68c5aaf",
+      "rapidapi-host": "api-nba-v1.p.rapidapi.com",
+    },
+  };
+
+  try {
+    const response = await fetch(url, options);
+    const data = await response.json();
+    const players = data.response;
+    for (const player of players) {
+        await prisma.refPlayer.upsert({
+            where: {id: player.id},
+            update: {metadata: player},
+            create: {
+                id: player.id,
+                metadata: player,
+            }
+        })
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+fetchNBAPlayers();

--- a/frontend/src/pages/FantasyBasketball.jsx
+++ b/frontend/src/pages/FantasyBasketball.jsx
@@ -85,9 +85,8 @@ const FantasyBasketball = ({ user, setUser }) => {
 
   const handleCreateLeague = async () => {
     if (!leagueName.trim() || !user?.id) return;
-    console.log("Bye");
+
     try {
-      console.log("Hello");
       const res = await fetch("http://localhost:5000/api/league", {
         method: "POST",
         headers: {
@@ -109,32 +108,6 @@ const FantasyBasketball = ({ user, setUser }) => {
       console.log("Create league fetch error: ", error);
     }
   };
-
-  //   const handleViewUserRoster = async () => {
-  //     try {
-  //     console.log("LLLLLLLLLLL");
-  //       const res = await fetch("http://localhost:5000/api/fantasyteam", {
-  //         method: "POST",
-  //         headers: {
-  //           "Content-Type": "application/json",
-  //         },
-  //         body: JSON.stringify({
-  //           name: user.name.trim(),
-  //           userId: user.id,
-  //         }),
-  //       });
-  //       const data = await res.json();
-  //       if (res.ok) {
-  //         setFantasyTeam((prev) => [...prev, data.fantasyteam]);
-  //         setFantasyTeamName("");
-  //       } else {
-  //         console.log("Create league error: ", data.error);
-  //       }
-  //     } catch (error) {
-  //       console.log("Create league fetch error: ", error);
-  //     }
-  //     }
-  //   }
 
   const handleLeagueClick = (league) => {
     navigate(`/league/${league.userId}/${league.leagueId}`);

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -51,48 +51,6 @@ function HomePage({ user, setUser }) {
     setOpenModal(false);
   };
 
-  useEffect(() => {
-    const fetchPlayerData = async () => {
-      const url =
-        "https://api-nba-v1.p.rapidapi.com/players?team=1&season=2021";
-      const options = {
-        method: "GET",
-        headers: {
-          "rapidapi-key": "cbca1b28d7msh153cb400f5cac43p1467e4jsn3649d68c5aaf",
-          "rapidapi-host": "api-nba-v1.p.rapidapi.com",
-        },
-      };
-
-      try {
-        const response = await fetch(url, options);
-        const result = await response.json();
-        console.log("Player data: ", result);
-        setPlayers(result);
-
-        const players = result.response;
-        for (const player of players) {
-          const body = {
-            id: player.id,
-            firstName: player.firstName,
-            lastName: player.lastName,
-            teamId: player.team?.id || null,
-          };
-
-          await fetch("/api/players", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(body)
-          });
-        }
-        console.log("Players successfully saved into backend");
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    fetchPlayerData();
-  }, []);
 
   return (
     <div className="homepage">

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -9,6 +9,7 @@ import TopBar from "../components/TopBar";
 function HomePage({ user, setUser }) {
   const [openModal, setOpenModal] = useState(false);
   const [openSidebar, setOpenSidebar] = useState(false);
+  const [players, setPlayers] = useState([]);
   const location = useLocation();
 
   useEffect(() => {
@@ -49,6 +50,49 @@ function HomePage({ user, setUser }) {
   const handleCloseModal = () => {
     setOpenModal(false);
   };
+
+  useEffect(() => {
+    const fetchPlayerData = async () => {
+      const url =
+        "https://api-nba-v1.p.rapidapi.com/players?team=1&season=2021";
+      const options = {
+        method: "GET",
+        headers: {
+          "rapidapi-key": "cbca1b28d7msh153cb400f5cac43p1467e4jsn3649d68c5aaf",
+          "rapidapi-host": "api-nba-v1.p.rapidapi.com",
+        },
+      };
+
+      try {
+        const response = await fetch(url, options);
+        const result = await response.json();
+        console.log("Player data: ", result);
+        setPlayers(result);
+
+        const players = result.response;
+        for (const player of players) {
+          const body = {
+            id: player.id,
+            firstName: player.firstName,
+            lastName: player.lastName,
+            teamId: player.team?.id || null,
+          };
+
+          await fetch("/api/players", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body)
+          });
+        }
+        console.log("Players successfully saved into backend");
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchPlayerData();
+  }, []);
 
   return (
     <div className="homepage">


### PR DESCRIPTION
This PR is to allow the api response to go directly into the database so that the api doesn't keep getting called. The next PR will be relating to the add functionality. This will allow users to add players into their fantasy rosters. I called the api from the backend and stored it as a JSON object. Then I was able to upsert the data into the RefPlayer model I created.

This will allow me to display the information about players that the users were interested in seeing. By sending it into the database, the api doesn't become a dependency anymore and I'm able to consistently display the information.

My information typically came from looking at how I did the operations for previous portions in my project and I just reworked it. Spencer, Ushana, and Dima also pitched in and helped me with the code. Prisma documentation was also very helpful during this process but unfortunately they didn't have the very specifics of what I needed so I resorted to google. 
https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/codemods#transforms

<img width="897" height="959" alt="Screenshot 2025-07-11 at 7 03 27 PM" src="https://github.com/user-attachments/assets/76363a61-cb34-438a-b18a-93e8a9d2c2bc" />

