### PR TITLE
Propose Trade Frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ dist-ssr
 
 .env
 
-/generated/prisma
+/generated/prisma/
+backend/prisma/migrations/*

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,10 +22,11 @@ model User {
   favoriteTeams   String[] // Changed to String[] because id of model Team is a String type
   favoritePlayers Int[] // Changed to Int[] becuase id of model Player is an Int type
   leagues         Int[] // Changed to Int[] because id of model League is an Int type
+  Trade           Trade[]
 }
 
 model Team {
-  id       String   @id // This is from the id the api assigns
+  id       String @id // This is from the id the api assigns
   players  Int[] // This refers to refPlayer model
   city     String
   nickName String
@@ -66,12 +67,12 @@ model League {
 }
 
 model Player {
-  playerId  Int     @id
-  firstName String
-  lastName  String
-  teamId    String? // Refers to real life team
-  fantasyTeamId     String? // Refers to fantasy team
-  value     Int
+  playerId      Int     @id
+  firstName     String
+  lastName      String
+  teamId        String? // Refers to real life team
+  fantasyTeamId String? // Refers to fantasy team
+  value         Int
 }
 
 model RefPlayer {
@@ -86,4 +87,14 @@ model FantasyTeam {
   playerIds Int[]
 
   @@id([userId, leagueId])
+}
+
+model Trade {
+  recordId    Int   @id @default(autoincrement())
+  tradeId     Int
+  proposerId  Int
+  user        User  @relation(fields: [proposerId], references: [id])
+  playersTo Int[]
+  userId      Int
+  confirmation Int
 }

--- a/backend/routes/fantasyteam.js
+++ b/backend/routes/fantasyteam.js
@@ -5,39 +5,6 @@ const prisma = new PrismaClient();
 
 const { addPlayerToFantasyTeam, removePlayerFromFantasyTeam}  = require("../utils/fantasyteamhelper");
 
-// To create fantasy team
-router.post("/:leagueId/fantasyteam", async (req, res) => {
-  try {
-    const { userId, leagueId, teamName } = req.body;
-
-    const existingTeam = await prisma.fantasyTeam.findUnique({
-      where: { userId_leagueId: { userId, leagueId } },
-    });
-
-    if (existingTeam) {
-      return res.status(400).json({
-        success: false,
-        error: "User already in fantasy team in this league",
-      });
-    }
-
-    const fantasyTeam = await prisma.fantasyTeam.create({
-      data: {
-        userId,
-        leagueId,
-        name: teamName,
-        playerIds: [],
-      },
-    });
-
-    return res.json({ success: true, fantasyTeam });
-  } catch (error) {
-    return res
-      .status(500)
-      .json({ success: false, error: "Not able to create fantasy team" });
-  }
-});
-
 // GET a user's fantasy team in a league
 router.get("/:userId/:leagueId", async (req, res) => {
   const { userId, leagueId } = req.params;

--- a/backend/routes/trade.js
+++ b/backend/routes/trade.js
@@ -1,0 +1,25 @@
+const express = require("express");
+const router = express.Router();
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+router.post("/", async (req, res) => {
+    const {proposerId, userId, leagueId} = req.body;
+    try {
+        const trade = await prisma.trade.create({
+            data: {
+                proposerId,
+                tradeId: Date.now(),
+                playersTo: [],
+                userId,
+                confirmation: 0,
+            }
+        })
+        res.status(201).json(trade);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({error: "Failed to create the trade propsosal"})
+    }
+})
+
+export default router;

--- a/backend/utils/fantasyteamhelper.js
+++ b/backend/utils/fantasyteamhelper.js
@@ -92,4 +92,26 @@ async function removePlayerFromFantasyTeam(userId, leagueId, playerId) {
   return updatedTeam;
 }
 
-module.exports = {addPlayerToFantasyTeam, removePlayerFromFantasyTeam};
+async function createFantasyTeam(userId, leagueId) {
+  const existingTeam = await prisma.fantasyTeam.findUnique({
+    where: { userId_leagueId: { userId, leagueId } },
+  });
+
+  if (existingTeam) {
+    return res.status(400).json({
+      success: false,
+      error: "User already in fantasy team in this league",
+    });
+  }
+
+  const fantasyTeam = await prisma.fantasyTeam.create({
+    data: {
+      userId,
+      leagueId,
+      name: "My team",
+      playerIds: [],
+    },
+  });
+}
+
+module.exports = {addPlayerToFantasyTeam, removePlayerFromFantasyTeam, createFantasyTeam};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -65,7 +65,7 @@ function App() {
           element={<LeaguePage user={user} setUser={setUser} handleLogout={handleLogout} />}
         />
         <Route
-          path="/fantasy-roster/:userId/:leagueId"
+          path="/:userId/:leagueId/fantasyteam"
           element={<FantasyRoster user={user} setUser={setUser} handleLogout={handleLogout} />}
         />
         <Route

--- a/frontend/src/components/ProposeTradeModal.css
+++ b/frontend/src/components/ProposeTradeModal.css
@@ -1,0 +1,108 @@
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0,0,0,0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+    overflow-y: auto;
+    z-index: 9999;
+}
+
+.modal-content {
+    background: white;
+    padding: 25px;
+    border-radius: 10px;
+    max-width: 450px;
+    max-height: 80vh;
+    width: 90%;
+    position: relative;
+    overflow-y: auto;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+
+.question-format {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+}
+
+.modal-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #333;
+    transition: color 0.2s ease;
+}
+
+.modal-close:hover {
+    color: #e74c3c
+}
+
+ul {
+    list-style-type: none;
+    padding: d0;
+    margin: 0;
+}
+
+li {
+    display: flex;
+    align-items: center;
+    padding: 8px 10px;
+    border-bottom: 1px solid black;
+    cursor: pointer;
+}
+
+li:last-child {
+    border-bottom: none;
+}
+
+li input[type="checkbox"] {
+    margin-right: 10px;
+    cursor: pointer;
+}
+
+li label {
+    flex-grow: 1;
+    user-select: none;
+}
+
+.players-checkbox-container {
+  display: flex;
+  flex-direction: column; 
+  gap: 20px;
+  margin-top: 1rem;
+}
+
+.player-list-column {
+  border: 1px solid #ccc;
+  padding: 10px;
+  border-radius: 6px;
+}
+
+.player-list-column h4 {
+  margin-bottom: 10px;
+}
+
+.trade-leg {
+  margin-bottom: 32px;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 16px;
+  display: flex;
+  flex-direction: column; 
+}
+
+.remove-button {
+    margin-left: 16px;
+    color: red;
+    cursor: pointer;
+    font-size: 20px;
+}
+

--- a/frontend/src/components/ProposeTradeModal.jsx
+++ b/frontend/src/components/ProposeTradeModal.jsx
@@ -1,0 +1,411 @@
+import React, { useState, useEffect } from "react";
+import "./ProposeTradeModal.css";
+
+const ProposeTradeModal = ({ open, onClose, leagueId }) => {
+  const [questionIndex, setQuestionindex] = useState(0);
+  const [leagueUsers, setLeagueUsers] = useState([]);
+  const [fantasyTeams, setFantasyTeams] = useState([]);
+  const [selectedUsers, setSelectedUsers] = useState([]);
+  const [tradeLegs, setTradeLegs] = useState([
+    {
+      user1: "",
+      user2: "",
+      user1Players: [],
+      user2Players: [],
+      user1PlayersToGive: [],
+      user2PlayersToGive: [],
+    },
+  ]);
+  const [validationError, setValidationError] = useState("");
+
+  const questions = [
+    {
+      id: 1,
+      label: "Which users in this league do you want to bring into this trade?",
+    },
+    { id: 2, label: "Proposer coordination" },
+    { id: 3, label: "Are you sure you want to propose this trade?" },
+  ];
+
+  // Fetch users and their players for the league on page load or leagueId change
+  useEffect(() => {
+    const fetchLeagueUsersAndPlayers = async () => {
+      try {
+        const res = await fetch(
+          `http://localhost:5000/api/league/${leagueId}/users-with-players`
+        );
+        const users = await res.json();
+        setLeagueUsers(users.users);
+        setFantasyTeams(users.result1);
+      } catch (error) {
+        console.error("Error fetching users with players:", error);
+      }
+    };
+    fetchLeagueUsersAndPlayers();
+  }, [leagueId]);
+
+  // This handles the checkbox selection on page 1 for selecting the users needed for the trade
+  const handleCheckboxMark = (userId) => {
+    setSelectedUsers((prev) => {
+      const user = leagueUsers.find((user) => user.id === userId);
+      // Toggle user in selectedUsers array
+      return prev.find(({ id }) => id === userId)
+        ? prev.filter(({ id }) => id !== userId)
+        : [...prev, user];
+    });
+  };
+
+  // Updates one field of a specific trade leg (immutable update)
+  const updateTradeLeg = (legIndex, field, value) => {
+    setTradeLegs((prevLegs) => {
+      const newLegs = [...prevLegs];
+      newLegs[legIndex] = { ...newLegs[legIndex], [field]: value }; 
+      return newLegs;
+    });
+  };
+
+  // Show all players when the specific user is selected
+  const showPlayersOnUserSelection = (
+    legIndex,
+    userId,
+    fieldParticipant,
+    fieldPlayers
+  ) => {
+    updateTradeLeg(legIndex, fieldParticipant, userId);
+
+    const user = fantasyTeams.find(
+      (user) => user.fantasyteam.userId === parseInt(userId) 
+    );
+
+    if (user && user.fantasyteam && user.refplayers) {
+      const playerList = user.refplayers.map((player) => ({
+        firstName: player.metadata.firstname,
+        lastName: player.metadata.lastname,
+        id: player.metadata.id,
+      }));
+      updateTradeLeg(legIndex, fieldPlayers, playerList);
+    }
+    setValidationError("");
+  };
+
+  // If a player is used in another leg, then it won't show in any new legs
+  const getSelectedPlayersInOtherLegs = (currentLegIndex, userId) => {
+    const selectedPlayersAcrossLegs = [];
+    tradeLegs.forEach((leg, legIndex) => {
+      if (legIndex !== currentLegIndex) {
+        if (leg.user1 === userId) {
+          selectedPlayersAcrossLegs.push(...leg.user1PlayersToGive);
+        }
+        if (leg.user2 === userId) {
+          selectedPlayersAcrossLegs.push(...leg.user2PlayersToGive);
+        }
+      }
+    });
+    return selectedPlayersAcrossLegs;
+  };
+
+  // Makes sure that the same pair of users don't trade with each other twice and they also have to trade at least one player
+  // It also makes sure they choose two participants
+  const validateTradeLegs = () => {
+    // Check for duplicate participant pairs ignoring order
+    const userPairs = tradeLegs
+      .map(({ user1, user2 }) =>
+        user1 && user2 ? [user1, user2].sort().join("-") : null
+      )
+      .filter(Boolean);
+
+    const pairsSet = new Set();
+    for (const pair of userPairs) {
+      if (pairsSet.has(pair)) {
+        setValidationError(
+          "Duplicate trade participant pairs are not allowed."
+        );
+        return false;
+      }
+      pairsSet.add(pair);
+    }
+
+    // Check each leg for participant and player selection
+    for (let i = 0; i < tradeLegs.length; i++) {
+      const leg = tradeLegs[i];
+      if (!leg.user1 || !leg.user2) {
+        setValidationError(`Select two users in trade leg ${i + 1}`);
+        return false;
+      }
+      if (
+        leg.user1PlayersToGive.length === 0 ||
+        leg.user2PlayersToGive.length === 0 ||
+        leg.user1 === leg.user2
+      ) {
+        setValidationError(
+          `Make sure to choose at least one unique player for each trade user in trade leg ${
+            i + 1
+          }`
+        );
+        return false;
+      }
+    }
+    setValidationError("");
+    return true;
+  };
+
+  const nextQuestion = () => {
+    if (questionIndex === 1) {
+      if (!validateTradeLegs()) return;
+    }
+    if (questionIndex < questions.length - 1) {
+      setQuestionindex((prev) => prev + 1);
+    }
+  };
+
+  const prevQuestion = () => {
+    if (questionIndex > 0) {
+      setQuestionindex((prev) => prev - 1);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (questionIndex === 1 && !validateTradeLegs()) return;
+    console.log("Trade proposal submitted with legs:", tradeLegs);
+    handleClose();
+  };
+
+  // This adds a new empty trade leg
+  const addTradeLeg = () => {
+    setTradeLegs((prev) => [
+      ...prev,
+      {
+        user1: "",
+        user2: "",
+        user1Players: [],
+        user2Players: [],
+        user1PlayersToGive: [],
+        user2PlayersToGive: [],
+      },
+    ]);
+    setValidationError("");
+  };
+
+  const removeTradeLeg = (legIndex) => {
+    setTradeLegs((prev) => {
+      const newLegs = prev.filter((_, index) => index !== legIndex);
+      return newLegs;
+    });
+    setValidationError("");
+  };
+
+  const clearAll = () => {
+    setQuestionindex(0);
+    setSelectedUsers([]);
+    setTradeLegs([
+      {
+        user1: "",
+        user2: "",
+        user1Players: [],
+        user2Players: [],
+        user1PlayersToGive: [],
+        user2PlayersToGive: [],
+      },
+    ]);
+    setValidationError("");
+  };
+
+  const handleClose = () => {
+    onClose();
+    clearAll();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-overlay" onClick={handleClose}>
+      <div
+        className="modal-content"
+        onClick={(event) => event.stopPropagation()}>
+        <button onClick={handleClose} className="modal-close">
+          Close
+        </button>
+
+        <h2>{questions[questionIndex].label}</h2>
+
+        {/* PAGE 1: SELECT THE USERS FOR TRADING*/}
+        {questionIndex === 0 && (
+          <ul>
+            {leagueUsers.map((user) => (
+              <li key={user.id}>
+                <input
+                  type="checkbox"
+                  checked={selectedUsers.some(({ id }) => id === user.id)}
+                  onChange={() => handleCheckboxMark(user.id)}
+                />
+                {user.name}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {/* PAGE 2: TRADE COORDINATION BY THE PROSPOSER */}
+        {questionIndex === 1 && (
+          <div className="question-format">
+            {tradeLegs.map((leg, legIndex) => {
+              const excludeUser1Players = leg.user1
+                ? getSelectedPlayersInOtherLegs(legIndex, leg.user1)
+                : [];
+
+              const filteredUser1Players = leg.user1Players.filter(
+                (player) => !excludeUser1Players.includes(player.id)
+              );
+
+              const excludeUser2Players = leg.user2
+                ? getSelectedPlayersInOtherLegs(legIndex, leg.user2)
+                : [];
+
+              const filteredUser2Players = leg.user2Players.filter(
+                (player) => !excludeUser2Players.includes(player.id)
+              );
+
+              return (
+                <div
+                  key={legIndex}
+                  className="trade-leg"
+                  id={`trade-leg-${legIndex}`}>
+                  <h3>
+                    Trade Leg {legIndex + 1}
+                    {legIndex > 0 && (
+                      <button
+                        onClick={() => removeTradeLeg(legIndex)}
+                        className="remove-button"
+                        title="Remove this trade leg">
+                        Remove
+                      </button>
+                    )}
+                  </h3>
+
+                  <label>Choose Trade Participant 1:</label>
+                  <select
+                    value={leg.user1}
+                    onChange={(event) =>
+                      showPlayersOnUserSelection(
+                        legIndex,
+                        event.target.value,
+                        "user1",
+                        "user1Players"
+                      )
+                    }>
+                    <option value="">-- Select --</option>
+                    {selectedUsers.map((user) => (
+                      <option key={user.id} value={user.id}>
+                        {user.name}
+                      </option>
+                    ))}
+                  </select>
+
+                  <label>Choose Trade Participant 2:</label>
+                  <select
+                    value={leg.user2}
+                    onChange={(event) =>
+                      showPlayersOnUserSelection(
+                        legIndex,
+                        event.target.value,
+                        "user2",
+                        "user2Players"
+                      )
+                    }>
+                    <option value="">-- Select --</option>
+                    {selectedUsers.map((user) => (
+                      <option key={user.id} value={user.id}>
+                        {user.name}
+                      </option>
+                    ))}
+                  </select>
+
+                  <div className="players-checkbox-container">
+                    {/* Participant 1 players */}
+                    {filteredUser1Players.length > 0 && (
+                      <div className="player-list-column">
+                        <h4>Participant 1 Players</h4>
+                        {filteredUser1Players.map((player) => (
+                          <label key={player.id}>
+                            <input
+                              type="checkbox"
+                              checked={leg.user1PlayersToGive.includes(
+                                player.id
+                              )}
+                              onChange={() => {
+                                const selected = [...leg.user1PlayersToGive, player.id];
+                                updateTradeLeg(
+                                  legIndex,
+                                  "user1PlayersToGive",
+                                  selected
+                                );
+                              }}
+                            />
+                            {player.firstName} {player.lastName}
+                          </label>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Participant 2 players */}
+                    {filteredUser2Players.length > 0 && (
+                      <div className="player-list-column">
+                        <h4>Participant 2 Players</h4>
+                        {filteredUser2Players.map((player) => (
+                          <label key={player.id}>
+                            <input
+                              type="checkbox"
+                              checked={leg.user2PlayersToGive.includes(
+                                player.id
+                              )}
+                              onChange={() => {
+                                const selected = [...leg.user2PlayersToGive, player.id];
+                                updateTradeLeg(
+                                  legIndex,
+                                  "user2PlayersToGive",
+                                  selected
+                                );
+                              }}
+                            />
+                            {player.firstName} {player.lastName}
+                          </label>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+            {/* Add trade button */}
+            <button onClick={addTradeLeg} style={{ marginTop: "16px" }}>
+              Add Another Leg To Trade
+            </button>
+            {/* Trade validation error message for user */}
+            {validationError && (
+              <p style={{ color: "red", marginTop: "16px" }}>
+                {validationError}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* PAGE 3: CONFIRMATION */}
+        {questionIndex === 2 && (
+          <div>
+            <button>No, Cancel</button>
+          </div>
+        )}
+
+        <button onClick={prevQuestion} disabled={questionIndex === 0}>
+          ←
+        </button>
+        {questionIndex < questions.length - 1 ? (
+          <button onClick={nextQuestion}>→</button>
+        ) : (
+          <button onClick={handleSubmit}>Submit</button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProposeTradeModal;

--- a/frontend/src/pages/FantasyRoster.jsx
+++ b/frontend/src/pages/FantasyRoster.jsx
@@ -8,6 +8,7 @@ import "./FantasyRoster.css";
 const FantasyRoster = ({ user, setUser, handleLogout }) => {
   const { userId, leagueId } = useParams();
   const [players, setPlayers] = useState([]);
+  const [dataPlayers, setDataPlayers] = useState([]);
   const [openModal, setOpenModal] = useState(false);
   const [openSidebar, setOpenSidebar] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -32,6 +33,24 @@ const FantasyRoster = ({ user, setUser, handleLogout }) => {
     };
     fetchRoster();
   }, [userId, leagueId]);
+
+  useEffect(() => {
+    const fetchAllPlayers = async () => {
+      try {
+        const res = await fetch("http://localhost:5000/api/refPlayers");
+        if (!res.ok) {
+          console.error(
+            "There is an error in fetching players PlayerMarketplace.jsx"
+          );
+        }
+        const data = await res.json();
+        setDataPlayers(data);
+      } catch (error) {
+        console.error("Error trying to fetch players in marketplace: ", error);
+      }
+    };
+    fetchAllPlayers();
+  }, []);
 
   const handleRemovePlayer = async (playerId) => {
     try {
@@ -91,6 +110,17 @@ const FantasyRoster = ({ user, setUser, handleLogout }) => {
                     }>
                     {playerId ? (
                       <div>
+                        <p>{`Player Name: ${
+                          dataPlayers.find((player) => player.id === playerId)
+                            ? dataPlayers.find(
+                                (player) => player.id === playerId
+                              ).metadata.firstname +
+                              " " +
+                              dataPlayers.find(
+                                (player) => player.id === playerId
+                              ).metadata.lastname
+                            : "Unknown"
+                        }`}</p>
                         <p>{`Player ID: ${playerId}`}</p>
                         <button
                           onClick={() => handleRemovePlayer(playerId)}

--- a/frontend/src/pages/LeaguePage.css
+++ b/frontend/src/pages/LeaguePage.css
@@ -26,15 +26,12 @@
 
 .league-members {
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
-    align-items: center;
-    border: 1px solid red;
+    align-items: flex-start;
     border-radius: 15px;
-    width: 50vw;
-    height: 60px;
-    background-color: white;
-    margin: 10px 0;
-    cursor: pointer;
+    padding: 10px;
+    gap: 10px;
 }
 
 .members-list {
@@ -45,4 +42,29 @@
     background-color: lightgray;
     height: 400px;
     overflow-y: auto;
+    margin-top: 200px;
+}
+
+.member-card {
+    border: 1px solid red;
+    border-radius: 15px;
+    width: 150px;
+    height: 60px;
+    background-color: white;
+    margin: 10px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.member-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.trade-proposal-button {
+    width: 100px;
+    height: 40px;
 }

--- a/frontend/src/pages/LeaguePage.jsx
+++ b/frontend/src/pages/LeaguePage.jsx
@@ -3,22 +3,24 @@ import { useNavigate, useParams } from "react-router-dom";
 import TopBar from "../components/TopBar";
 import SidebarModal from "../components/SideBarModal";
 import AccountModal from "../Components/AccountModal";
+import ProposeTradeModal from "../components/ProposeTradeModal";
 import "./LeaguePage.css";
 
-const LeaguePage = ({user, setUser, handleLogout }) => {
+const LeaguePage = ({ user, setUser, handleLogout }) => {
   const { leagueId } = useParams();
   const navigate = useNavigate();
   const [league, setLeague] = useState(null);
   const [openModal, setOpenModal] = useState(false);
   const [openSidebar, setOpenSidebar] = useState(false);
+  const [showTradeModal, setShowTradeModal] = useState(false);
 
   useEffect(() => {
     const fetchLeague = async () => {
-      console.log("leagueId: ", leagueId);
       try {
         const res = await fetch(`http://localhost:5000/api/league/${leagueId}`);
         const data = await res.json();
-        setLeague(data.league);
+        const temp = data.league;
+        setLeague(temp);
       } catch (error) {
         console.log("LeaguePage error fetching league: ", error);
         navigate("/fantasy-basketball");
@@ -34,7 +36,13 @@ const LeaguePage = ({user, setUser, handleLogout }) => {
         onHamburgClick={() => setOpenSidebar((prev) => !prev)}
         onProfileClick={() => setOpenModal(true)}
       />
-      {openModal && <AccountModal setOpenModal={setOpenModal} user={user} handleLogout={handleLogout} />}
+      {openModal && (
+        <AccountModal
+          setOpenModal={setOpenModal}
+          user={user}
+          handleLogout={handleLogout}
+        />
+      )}
       {openSidebar && <SidebarModal setOpenSidebar={setOpenSidebar} />}
       <div className="league-top-container">
         <button
@@ -51,6 +59,17 @@ const LeaguePage = ({user, setUser, handleLogout }) => {
           <p>League ID: {league?.leagueId}</p>
           <p>Number of Members: {league?.users?.length || 0}</p>
         </div>
+        <button
+          className="trade-proposal-button"
+          onClick={() => setShowTradeModal(true)}>
+          Create Trade
+          </button>
+          <ProposeTradeModal
+            open={showTradeModal}
+            onClose={() => setShowTradeModal(false)}
+            leagueId={leagueId}
+          
+          />
       </div>
       <div className="members-list">
         <div className="league-members">
@@ -59,7 +78,9 @@ const LeaguePage = ({user, setUser, handleLogout }) => {
               <div
                 key={user.id}
                 className="member-card"
-                onClick={() => navigate(`/fantasy-roster/${user.id}/${league?.leagueId}`)}>
+                onClick={() =>
+                  navigate(`/${user.id}/${league?.leagueId}/fantasyteam`)
+                }>
                 <h4 className="member-name">{user.name}</h4>
               </div>
             ))


### PR DESCRIPTION
This pull request allows the proposer to decide on who is in the trade and who isn't. They are able to select those specific users and once they are selected, the proposer will go to the next page where they can decide on which users trade with who and what players are given to them.

The next PR will create the confirmation POST and update the database with the tradeId. Then users will be able to track if they have pending trades through a fetch (being seeing if there is a tradeId record associated with their userId.

This allows users to more immersed in the fantasy basketball experience. It allows them to do the first step of deciding which users will be trading with who and what players they'll be giving them.

I got a lot of help from Spencer, Ushana, Dima, Lennard, and some other online resources. But a lot of how I created what I did was leveraging what others showed me how to do and making it into my own version that I need for the project.

I did do a lot of edge cases including not allowing users to have duplicate pairs of trading (so user1 and user2 won't be apart of 2 separate trade legs together).

I will send the video demo in the workplace chat because it is too big to fit on here!

